### PR TITLE
Adds support for import statements to parser

### DIFF
--- a/src/main/c/frontend/lexical-analysis/FlexActions.c
+++ b/src/main/c/frontend/lexical-analysis/FlexActions.c
@@ -252,11 +252,13 @@ Token ImportLexemeAction(LexicalAnalyzerContext * lexicalAnalyzerContext) {
 	destroyLexicalAnalyzerContext(lexicalAnalyzerContext);
 	return IMPORT;
 }
+
 Token ImportFileLexemeAction(LexicalAnalyzerContext * lexicalAnalyzerContext) {
 	_logLexicalAnalyzerContext(__FUNCTION__, lexicalAnalyzerContext);
 	lexicalAnalyzerContext->semanticValue->token = IMPORT_PATH;
 	destroyLexicalAnalyzerContext(lexicalAnalyzerContext);
 	return IMPORT_PATH;
+}
 
 Token ReturnLexemeAction(LexicalAnalyzerContext * lexicalAnalyzerContext) {
 	_logLexicalAnalyzerContext(__FUNCTION__, lexicalAnalyzerContext);

--- a/src/main/c/frontend/lexical-analysis/FlexActions.c
+++ b/src/main/c/frontend/lexical-analysis/FlexActions.c
@@ -245,3 +245,16 @@ Token ClassLexemeAction(LexicalAnalyzerContext * lexicalAnalyzerContext) {
 	destroyLexicalAnalyzerContext(lexicalAnalyzerContext);
 	return CLASS;
 }
+
+Token ImportLexemeAction(LexicalAnalyzerContext * lexicalAnalyzerContext) {
+	_logLexicalAnalyzerContext(__FUNCTION__, lexicalAnalyzerContext);
+	lexicalAnalyzerContext->semanticValue->token = IMPORT;
+	destroyLexicalAnalyzerContext(lexicalAnalyzerContext);
+	return IMPORT;
+}
+Token ImportFileLexemeAction(LexicalAnalyzerContext * lexicalAnalyzerContext) {
+	_logLexicalAnalyzerContext(__FUNCTION__, lexicalAnalyzerContext);
+	lexicalAnalyzerContext->semanticValue->token = IMPORT_PATH;
+	destroyLexicalAnalyzerContext(lexicalAnalyzerContext);
+	return IMPORT_PATH;
+}

--- a/src/main/c/frontend/lexical-analysis/FlexActions.h
+++ b/src/main/c/frontend/lexical-analysis/FlexActions.h
@@ -39,6 +39,9 @@ Token UnknownLexemeAction(LexicalAnalyzerContext * lexicalAnalyzerContext);
 Token SemicolonLexemeAction(LexicalAnalyzerContext * lexicalAnalyzerContext);
 Token DecoratorLexemeAction(LexicalAnalyzerContext * lexicalAnalyzerContext,Token token);
 
+Token ImportLexemeAction(LexicalAnalyzerContext * lexicalAnalyzerContext);
+Token ImportFileLexemeAction(LexicalAnalyzerContext * lexicalAnalyzerContext);
+
 Token NameLexemeAction(LexicalAnalyzerContext * lexicalAnalyzerContext);
 Token ColonLexemeAction(LexicalAnalyzerContext * lexicalAnalyzerContext);
 Token TypeLexemeAction(LexicalAnalyzerContext * lexicalAnalyzerContext, VariableType token); 

--- a/src/main/c/frontend/lexical-analysis/FlexPatterns.l
+++ b/src/main/c/frontend/lexical-analysis/FlexPatterns.l
@@ -16,13 +16,15 @@
 %x CHAR_CONSTANT
 %x STRING_CONSTANT
 
+
 /** ========================================= Reusable patterns. ========================================= */
 /** ------------------ [ @see https://westes.github.io/flex/manual/Matching.html ] ------------------*/
 /** ------------------ [ @see https://westes.github.io/flex/manual/Patterns.html ] ------------------*/
 digit			      [0-9]
 char                  [a-zA-Z_]
 name                  {char}({char}|{digit})*
-single_line_comment     "#"[^!].*
+path                  \"[^\"]*\\.arcx\"
+single_line_comment   "#"[^!].*
 
 %%
 "#!"								{ BEGIN(MULTILINE_COMMENT); BeginMultilineCommentLexemeAction(createLexicalAnalyzerContext()); }
@@ -31,7 +33,10 @@ single_line_comment     "#"[^!].*
 <MULTILINE_COMMENT>.				{ IgnoredLexemeAction(createLexicalAnalyzerContext()); }
 <MULTILINE_COMMENT>"!#"				{ EndMultilineCommentLexemeAction(createLexicalAnalyzerContext()); BEGIN(INITIAL); }
 
-<INITIAL>{single_line_comment}               { IgnoredLexemeAction(createLexicalAnalyzerContext()); }  
+<INITIAL>{single_line_comment}      { IgnoredLexemeAction(createLexicalAnalyzerContext()); }  
+
+"#import"                         	{ return ImportLexemeAction(createLexicalAnalyzerContext()); }
+{path}                				{ return ImportFileLexemeAction(createLexicalAnalyzerContext()); }
 
 "-"						            { return ArithmeticOperatorLexemeAction(createLexicalAnalyzerContext(), SUB); }
 "*"									{ return ArithmeticOperatorLexemeAction(createLexicalAnalyzerContext(), MUL); }

--- a/src/main/c/frontend/lexical-analysis/FlexPatterns.l
+++ b/src/main/c/frontend/lexical-analysis/FlexPatterns.l
@@ -35,8 +35,7 @@ single_line_comment   "#"[^!].*
 
 <INITIAL>{single_line_comment}      { IgnoredLexemeAction(createLexicalAnalyzerContext()); }  
 
-"#import"                         	{ return ImportLexemeAction(createLexicalAnalyzerContext()); }
-{path}                				{ return ImportFileLexemeAction(createLexicalAnalyzerContext()); }
+"import"                         	{ return ImportLexemeAction(createLexicalAnalyzerContext()); }
 
 "-"						            { return ArithmeticOperatorLexemeAction(createLexicalAnalyzerContext(), SUB); }
 "*"									{ return ArithmeticOperatorLexemeAction(createLexicalAnalyzerContext(), MUL); }

--- a/src/main/c/frontend/syntactic-analysis/AbstractSyntaxTree.c
+++ b/src/main/c/frontend/syntactic-analysis/AbstractSyntaxTree.c
@@ -186,10 +186,22 @@ void releaseClass(Class * class) {
 	free(class);
 }
 
+void releaseImport(Import * import_statement)
+{
+	if (import_statement == NULL)return;
+
+	if(import_statement->PathToFile != NULL)
+	{
+		free(import_statement->PathToFile);
+		free(import_statement);
+	}
+
+}
+
 void releaseProgram(Program * program) {
 	logDebugging(_logger, "Executing destructor: %s", __FUNCTION__);
 	if(program == NULL) return;
-
+	releaseImportList(program->importList);
 	releaseBlock(program->block);
 	free(program);
 }
@@ -263,7 +275,11 @@ void releaseList(List * list, releaseDataFn release_fun) {
 }
 
 // ======= Specialized lists ======= //
-
+void releaseImportList(ImportList * importList)
+{
+	logDebugging(_logger, "Executing destructor: %s", __FUNCTION__);
+	return releaseList(importList,  (releaseDataFn) releaseImport);
+}
 // Expressions.
 void releaseExpressionList(ExpressionList * expressionList){
 	logDebugging(_logger, "Executing destructor: %s", __FUNCTION__);

--- a/src/main/c/frontend/syntactic-analysis/AbstractSyntaxTree.c
+++ b/src/main/c/frontend/syntactic-analysis/AbstractSyntaxTree.c
@@ -190,17 +190,13 @@ void releaseImport(Import * import_statement)
 {
 	if (import_statement == NULL)return;
 
-	if(import_statement->PathToFile != NULL)
-	{
-		free(import_statement->PathToFile);
-		free(import_statement);
-	}
+	free(import_statement->PathToFile);
+	free(import_statement);
 
 }
 
 void releaseProgram(Program * program) {
 	logDebugging(_logger, "Executing destructor: %s", __FUNCTION__);
-	if(program == NULL) return;
 	releaseImportList(program->importList);
 	releaseBlock(program->block);
 	free(program);
@@ -277,7 +273,7 @@ void releaseList(List * list, releaseDataFn release_fun) {
 // ======= Specialized lists ======= //
 void releaseImportList(ImportList * importList)
 {
-	logDebugging(_logger, "Executing destructor: %s", __FUNCTION__);
+	logError(_logger, "Executing destructor: %s", __FUNCTION__);
 	return releaseList(importList,  (releaseDataFn) releaseImport);
 }
 // Expressions.
@@ -306,7 +302,7 @@ void releasePrivacyList(PrivacyList * privacyList){
 
 // Implementation List.
 void releaseImplementationList(ImplementationList * implementationList){
-	logDebugging(_logger, "Executing destructor: %s", __FUNCTION__);
+	logError(_logger, "Executing destructor: %s", __FUNCTION__);
 	return releaseList(implementationList, (releaseDataFn) releaseObject);
 }
 

--- a/src/main/c/frontend/syntactic-analysis/AbstractSyntaxTree.h
+++ b/src/main/c/frontend/syntactic-analysis/AbstractSyntaxTree.h
@@ -36,6 +36,7 @@ typedef struct Instruction Instruction;
 typedef struct Lambda Lambda;
 typedef struct Class Class;
 typedef struct Interface Interface;
+typedef struct Import Import;
 
 typedef struct FunctionCall FunctionCall;
 
@@ -54,6 +55,9 @@ typedef void (*releaseDataFn)(void *);
 #pragma region Specialized Lists
 typedef Node ExpressionNode;
 typedef List ExpressionList;
+
+typedef Node ImportStatementNode;
+typedef List ImportList;
 
 typedef Node VariableDeclarationNode;
 typedef List VariableDeclarationList;
@@ -252,6 +256,10 @@ struct Lambda {
 	Instruction * instruction;
 };
 
+struct Import{
+	char * PathToFile;
+};
+
 struct Class {
 	Object * object;
 	Object * inherits;
@@ -281,6 +289,7 @@ struct Generic {
 };
 
 struct Program {
+	ImportList * importList;
 	Block * block;
 	Loop * loop;
 };
@@ -441,6 +450,18 @@ void releaseImplementationList(ImplementationList * implementationList);
  * @param interface Pointer to the interface to be released.
  */
 void releaseInterface(Interface * interface);
+
+/**
+ * @brief Releases all resources associated with the given ImportList.
+ *
+ * This function frees any memory allocated for the ImportList and its contents.
+ * After calling this function, the ImportList pointer should not be used unless reinitialized.
+ *
+ * @param importList Pointer to the ImportList to be released.
+ */
+void releaseImportList(ImportList * importList);
+
+void releaseImport(Import * import_statement);
 #pragma endregion
 // =======================================================
 

--- a/src/main/c/frontend/syntactic-analysis/BisonActions.c
+++ b/src/main/c/frontend/syntactic-analysis/BisonActions.c
@@ -238,9 +238,10 @@ Expression * LambdaExpressionSemanticAction(Lambda * lambda) {
 	return expression;
 }
 
-Program * BlockProgramSemanticAction(CompilerState * compilerState, Block * block) {
+Program * BlockProgramSemanticAction(CompilerState * compilerState,ImportList * importList, Block * block) {
 	_logSyntacticAnalyzerAction(__FUNCTION__);
 	Program * program = calloc(1, sizeof(Program));
+	program->importList = importList;
 	program->block = block;
 	compilerState->abstractSyntaxtTree = program;
 	if (0 < flexCurrentContext()) {
@@ -329,6 +330,16 @@ Interface * InterfaceSemanticAction(Object * object, ImplementationList * extend
 	return interface;
 }
 
+// ===== Imports =====
+Import * ImportSemanticAction(char * path)
+{
+	_logSyntacticAnalyzerAction(__FUNCTION__);
+	Import * import_statement = calloc(1,sizeof(Import));
+	import_statement->PathToFile;
+	return import_statement;
+}
+
+
 /**
  * ============== LIST ==============
  */
@@ -407,4 +418,9 @@ ImplementationList * ImplementationListSemanticAction(ImplementationList * imple
 Block * BlockSemanticAction(Block * block, Instruction * instruction){
 	_logSyntacticAnalyzerAction(__FUNCTION__);
 	return ListSemanticAction(block, instruction);
+}
+ImportList * ImportListSemanticAction(ImportList * importList, Import * importStatement)
+{
+	_logSyntacticAnalyzerAction(__FUNCTION__);
+	return ListSemanticAction(importList,importStatement);
 }

--- a/src/main/c/frontend/syntactic-analysis/BisonActions.c
+++ b/src/main/c/frontend/syntactic-analysis/BisonActions.c
@@ -335,7 +335,7 @@ Import * ImportSemanticAction(char * path)
 {
 	_logSyntacticAnalyzerAction(__FUNCTION__);
 	Import * import_statement = calloc(1,sizeof(Import));
-	import_statement->PathToFile;
+	import_statement->PathToFile = path;
 	return import_statement;
 }
 

--- a/src/main/c/frontend/syntactic-analysis/BisonActions.h
+++ b/src/main/c/frontend/syntactic-analysis/BisonActions.h
@@ -194,7 +194,23 @@ AssignmentOperation * AssignmentOperatorSemanticAction(char * name, Expression *
 Instruction * InstructionSemanticAction(void * value, InstructionType instructionType);
 #pragma endregion
 // ========================================================
+// ================== [ Imports ] ==========================
+#pragma region Imports
+/**
+ * Creates an import statement with the specified module name.
+ * @param path The path to the module to import with the name.
+ * @return A pointer to the created import statement.
+ */
+Import * ImportSemanticAction(char * path);
 
+/**
+ * Creates an import list with the specified list and import statement.
+ * @param importList The existing list of imports.
+ * @param importStatement The import statement to add.
+ * @return A pointer to the created import list.
+ */
+ImportList * ImportListSemanticAction(ImportList * importList, Import * importStatement);
+#pragma endregion
 // ================== [ Blocks ] ==========================
 #pragma region Blocks
 /**
@@ -284,7 +300,7 @@ ExpressionList * ExpressionListSemanticAction(ExpressionList * expressionList, E
  * @param block The program block.
  * @return A pointer to the created program.
  */
-Program * BlockProgramSemanticAction(CompilerState * compilerState, Block * block);
+Program * BlockProgramSemanticAction(CompilerState * compilerState,ImportList * importList, Block * block);
 
 /**
  * Creates a program from a loop.

--- a/src/main/c/frontend/syntactic-analysis/BisonGrammar.y
+++ b/src/main/c/frontend/syntactic-analysis/BisonGrammar.y
@@ -89,6 +89,8 @@
 %destructor { releaseImplementationList($$); } <implementationList>
 %destructor { releasePrivacyList($$); } <privacyList>
 %destructor { releasePrivacyModifier($$); } <privacy>
+%destructor { releaseImportList($$); } <importList>
+%destructor { releaseImport($$); } <importStatement>
 
 /** ============== TERMINALS. ============== */
 	// ------------------ [ Non-Tokens ] ------------------
@@ -268,8 +270,8 @@
 
 	// ------------------ [ Program Structure ] ------------------
 		program:
-			import_list[import] block[code]																				{ $$ = BlockProgramSemanticAction(currentCompilerState(),$import,$1); }
-			| block[code]																								{ $$ = BlockProgramSemanticAction(currentCompilerState(),NULL ,$1); }
+			import_list block																							{ $$ = BlockProgramSemanticAction(currentCompilerState(),$1,$2); }
+			| block																										{ $$ = BlockProgramSemanticAction(currentCompilerState(),NULL ,$1); }
 			;
 
 		block:
@@ -277,12 +279,12 @@
 			| block instruction																							{ $$ = BlockSemanticAction($1, $2); }
 			;
 
-		import_list:
-			import_list import_statment																					{ $$ = ImportListSemanticAction($1, $2); }	
+		import_list: import_statment																					{ $$ = ImportListSemanticAction(NULL,$1); }
+			| import_list import_statment																				{ $$ = ImportListSemanticAction($1, $2); }	
 			;
 
 		import_statment:
-			IMPORT IMPORT_PATH 																							{ $$ = ImportStatementSemanticAction($2); }
+			IMPORT C_STRING 																						  	{ $$ = ImportSemanticAction($2); }
 			;
 		instruction:
 			assignment_operation SEMICOLON																				{ $$ = InstructionSemanticAction($1, INSTRUCTION_ASSIGNMENT); }

--- a/src/main/c/frontend/syntactic-analysis/BisonGrammar.y
+++ b/src/main/c/frontend/syntactic-analysis/BisonGrammar.y
@@ -19,16 +19,19 @@
 	Token token;
 	
 	/** Non-terminals. */
+	ImportList * importList;
+	Import * importStatement;
+
 	Constant * constant;
 	Conditional * conditional;
 
 	Expression * expression;
-	Expression * comparator_expression;
+	Expression * comparatorExpression;
 
 	Factor * factor;
 	Program * program;
 	Loop * loop;
-
+	
 	PrivacyModifier * privacy;
 	PrivacyList * privacyList;	
 	VariableDeclaration * variableDeclaration;
@@ -153,7 +156,7 @@
 		%token <token> SUB_ASSIGN
 		%token <token> MUL_ASSIGN
 
-	// ------------------ [ Control Structures ] ----------
+	// ------------------ [ Control Structures ] ------------------
 		/** ===== Loops ===== */
 		%token <token> WHILE
 		%token <token> FOR
@@ -163,6 +166,10 @@
 		%token <token> ELSE
 
 	// ------------------ [ Classes ] ---------------------
+		/** ===== Imports ===== */
+		%token <token> IMPORT
+		%token <c_string> IMPORT_PATH
+
 		/** ===== Class ===== */
 		%token <token> CLASS
 
@@ -201,6 +208,8 @@
 		%type <loop> loop
 
 	// ------------------ [ Program Structure ] ------------------
+		%type <importList> import_list
+		%type <importStatement> import_statment
 		%type <program> program
 		%type <block> block
 		%type <block> scope
@@ -235,8 +244,8 @@
 			%type <genericList> generic_list
 		/** ===== Interfaces ===== */
 			%type <inter> interface
-		/** ===== IMplementactions ===== */
-	
+
+		/** ===== Implementactions ===== */
 			%type <implementationList> implementation
 			%type <implementationList> implementation_list
 		/** ===== Inheritance ===== */
@@ -258,8 +267,9 @@
 	// IMPORTANT: To use λ in the following grammar, use the %empty symbol.
 
 	// ------------------ [ Program Structure ] ------------------
-		program: 
-			block																										{ $$ = BlockProgramSemanticAction(currentCompilerState(), $1); }
+		program:
+			import_list[import] block[code]																				{ $$ = BlockProgramSemanticAction(currentCompilerState(),$import,$1); }
+			| block[code]																								{ $$ = BlockProgramSemanticAction(currentCompilerState(),NULL ,$1); }
 			;
 
 		block:
@@ -267,6 +277,13 @@
 			| block instruction																							{ $$ = BlockSemanticAction($1, $2); }
 			;
 
+		import_list:
+			import_list import_statment																					{ $$ = ImportListSemanticAction($1, $2); }	
+			;
+
+		import_statment:
+			IMPORT IMPORT_PATH 																							{ $$ = ImportStatementSemanticAction($2); }
+			;
 		instruction:
 			assignment_operation SEMICOLON																				{ $$ = InstructionSemanticAction($1, INSTRUCTION_ASSIGNMENT); }
 			| variable_declaration SEMICOLON																			{ $$ = InstructionSemanticAction($1, INSTRUCTION_VARIABLE_DECLARATION); }

--- a/src/test/c/accept/26-import.arcx
+++ b/src/test/c/accept/26-import.arcx
@@ -1,0 +1,2 @@
+import "this/is/a/test.arcx"
+class ClassName { }


### PR DESCRIPTION
### Overview

- Implements parsing and AST support for import statements, allowing source files to include other modules.
- Updates lexical rules to recognize import keywords and import paths.
- Introduces structures and memory management for import lists in the syntax tree.
- Adjusts semantic actions and grammar rules to incorporate imports at the program level.
- Adds a basic test case for the import syntax.

### Motivation

Enables modularity and code reuse by allowing files to import other modules, laying the foundation for multi-file projects and dependency management.

### Details

- New semantic actions and AST nodes handle import statements.
- Ensures proper cleanup of import lists and entries.
- Grammar now parses optional import lists before the main code block.

No related issue referenced.