### PR TITLE
Fix generator output and expression concatenation

### DIFF
--- a/src/main/c/backend/code-generation/ExpressionGenerator.c
+++ b/src/main/c/backend/code-generation/ExpressionGenerator.c
@@ -105,7 +105,7 @@ char* generateExpression(const unsigned int indentationLevel, Expression* expres
             char* operator = _expressionTypeToOperator(expression->type);
             
             if (leftExpr && rightExpr && operator) {
-                result = concatenate(5, indent, "(", leftExpr, " ", operator, " ", rightExpr, ")");
+                result = concatenate(8, indent, "(", leftExpr, " ", operator, " ", rightExpr, ")");
             }
             
             free(leftExpr);

--- a/src/main/c/backend/code-generation/Generator.c
+++ b/src/main/c/backend/code-generation/Generator.c
@@ -76,9 +76,10 @@ static void _generateExpression(const unsigned int indentationLevel, Expression 
 		case DIVISION:
 		case MULTIPLICATION:
 		case SUBTRACTION:
-			_generateExpression(1 + indentationLevel, expression->leftExpression);
-			_output(1 + indentationLevel, "%c");
-			_generateExpression(1 + indentationLevel, expression->rightExpression);
+                        _generateExpression(1 + indentationLevel, expression->leftExpression);
+                        char op = _expressionTypeToCharacter(expression->type);
+                        _output(1 + indentationLevel, "%c", op);
+                        _generateExpression(1 + indentationLevel, expression->rightExpression);
 			break;
 		case FACTOR:
 			_generateFactor(1 + indentationLevel, expression->factor);


### PR DESCRIPTION
## Summary
- fix segment count for concatenate call in `generateExpression`
- ensure operator character is passed to `_output` in `_generateExpression`

## Testing
- `bash script/ubuntu/build.sh` *(fails: `bison` missing)*
- `bash script/ubuntu/test.sh` *(fails: compiler not built)*

------
https://chatgpt.com/codex/tasks/task_e_684f3d39ec208326aeb3e81cc16d207f